### PR TITLE
desactivate slack alerts on api error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,7 +90,6 @@ async function main(): Promise<void> {
     try {
       await loop();
     } catch (e) {
-      sendToSlack(`Error: ${e}`);
       await new Promise((res) => setTimeout(res, 300000));
     }
   }


### PR DESCRIPTION
Don't notify on slack in case of Error
Because the goal of the tester is to check the balance update and if the API is not reachable we will already have another alert